### PR TITLE
Update IPMI-Default-Password-List.mdown

### DIFF
--- a/IPMI-Default-Password-List.mdown
+++ b/IPMI-Default-Password-List.mdown
@@ -9,3 +9,4 @@
 |Supermicro IPMI                                |ADMIN        |ADMIN                                |
 |Oracle Integrated Lights Out Manager           |root         |changeme                             |
 |ASUS iKVM BMC                                  |admin        |admin                                |
+|QuantaMesh BMC                                 |qct.admin    |qct.admin                            |


### PR DESCRIPTION
adding QuantaMesh default BMC credentials